### PR TITLE
Fix the Enter keyboard shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Minor Version: Exolve v1.58.8: December 16, 2024
+
+- Fix the Enter keyboard shortcut to switch directions.
+
 ### Minor Version: Exolve v1.58.7: December 11, 2024
 
 - 'Check this' and 'Check all!' used to behave like 'Reveal this' and

--- a/exolve-m.js
+++ b/exolve-m.js
@@ -5921,7 +5921,7 @@ Exolve.prototype.toggleCurrDir = function() {
 
 Exolve.prototype.toggleCurrDirAndActivate = function(e) {
   this.usingGnav = true;
-  if (e && !e.shiftKey) {
+  if (!(e && e.shiftKey)) {
     this.toggleCurrDir();
   }
   this.activateCell(this.currRow, this.currCol);

--- a/exolve.html
+++ b/exolve.html
@@ -5968,7 +5968,7 @@ Exolve.prototype.toggleCurrDir = function() {
 
 Exolve.prototype.toggleCurrDirAndActivate = function(e) {
   this.usingGnav = true;
-  if (e && !e.shiftKey) {
+  if (!(e && e.shiftKey)) {
     this.toggleCurrDir();
   }
   this.activateCell(this.currRow, this.currCol);


### PR DESCRIPTION
This pull request fixes the Enter keyboard shortcut, which should toggle the current entry direction. Previously, pressing Enter would do nothing. The bug was caused by commit e6ea8908dec435ec7965738b107452b240a25f96.